### PR TITLE
Use better shell exec of bash shell

### DIFF
--- a/gh-alerts
+++ b/gh-alerts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 help() {


### PR DESCRIPTION
Make use of env instead of assuming bash in a specific path.

Signed-off-by: Eric Brown <browne@vmware.com>